### PR TITLE
POC: Re-introducing Sorbet types to RSpec partial test double

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -66,7 +66,7 @@ module RSpec
           key = T::Private::Methods.send(:method_owner_and_name_to_key, self, method_name)
           sig = T::Private::Methods.send(:signature_for_key, key)
           if sig
-            T::Private::Methods::CallValidation.rewrap_method(
+            T::Private::Methods::CallValidation.wrap_method_if_needed(
               self,
               sig,
               instance_method(method_name)

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -63,6 +63,15 @@ module RSpec
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end
+          key = T::Private::Methods.send(:method_owner_and_name_to_key, self, method_name)
+          sig = T::Private::Methods.send(:signature_for_key, key)
+          if sig
+            T::Private::Methods::CallValidation.rewrap_method(
+              self,
+              sig,
+              instance_method(method_name)
+            )
+          end
           # This can't be `if respond_to?(:ruby2_keywords, true)`,
           # see https://github.com/rspec/rspec-mocks/pull/1385#issuecomment-755340298
           ruby2_keywords(method_name) if Module.private_method_defined?(:ruby2_keywords)


### PR DESCRIPTION
This is intended as a demonstration of the concept proposed in https://github.com/sorbet/sorbet/issues/5683.
