### PR TITLE
POC: Re-introducing Sorbet types to RSpec partial test double

### DIFF
--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -69,7 +69,16 @@ module RSpec
           __send__(visibility, method_name)
 
           method = instance_method(method_name)
+
+          # TODO: Just calling signature_for_method without calling wrap_method_... affects the outcome of the tests
+          # only when the bad parameter test runs before the bad return test, and I am not sure why.
+          # The error we get is:
+          #   (DiscussionDomain (class)).comment_ids_for_blog("1")
+          #     expected: 1 time with arguments: ("1")
+          #     received: 0 times
+          # So presumably its that the test's mocking proxy is not being set up correctly.
           signature = T::Utils.signature_for_method(method)
+
           if signature
             T::Utils.wrap_method_with_call_validation_if_needed(self, signature, method)
           end

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -66,7 +66,7 @@ module RSpec
           key = T::Private::Methods.send(:method_owner_and_name_to_key, self, method_name)
           sig = T::Private::Methods.send(:signature_for_key, key)
           if sig
-            T::Private::Methods::CallValidation.rewrap_method(
+            T::Private::Methods::CallValidation.wrap_method_if_needed(
               self,
               sig,
               instance_method(method_name)

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -63,6 +63,15 @@ module RSpec
           define_method(method_name) do |*args, &block|
             method_double.proxy_method_invoked(self, *args, &block)
           end
+          key = T::Private::Methods.send(:method_owner_and_name_to_key, self, method_name)
+          sig = T::Private::Methods.send(:signature_for_key, key)
+          if sig
+            T::Private::Methods::CallValidation.rewrap_method(
+              self,
+              sig,
+              instance_method(method_name)
+            )
+          end
           # This can't be `if respond_to?(:ruby2_keywords, true)`,
           # see https://github.com/rspec/rspec-mocks/pull/1385#issuecomment-755340298
           ruby2_keywords(method_name) if Module.private_method_defined?(:ruby2_keywords)

--- a/lib/rspec/mocks/method_double.rb
+++ b/lib/rspec/mocks/method_double.rb
@@ -68,11 +68,10 @@ module RSpec
           ruby2_keywords(method_name) if Module.private_method_defined?(:ruby2_keywords)
           __send__(visibility, method_name)
 
-          signature = T::Utils.signature_for_method(instance_method(method_name))
+          method = instance_method(method_name)
+          signature = T::Utils.signature_for_method(method)
           if signature
-            T::Utils.wrap_method_with_call_validation_if_needed(
-              self, signature, instance_method(method_name)
-            )
+            T::Utils.wrap_method_with_call_validation_if_needed(self, signature, method)
           end
         end
 

--- a/sorbet-demonstration.rb
+++ b/sorbet-demonstration.rb
@@ -1,0 +1,49 @@
+# typed: true
+
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'sorbet'
+  gem 'sorbet-runtime'
+  gem 'rspec', '3.11'
+  gem 'rspec-mocks', path: "./"
+end
+
+class Blog
+  def initialize(id)
+    @id = id
+  end
+  def comment_ids
+    DiscussionDomain.comment_ids_for_blog(@id)
+  end
+end
+
+class DiscussionDomain
+  extend T::Sig
+
+  sig {params(blog_id: Integer).returns(T::Array[Integer])}
+  def self.comment_ids_for_blog(blog_id)
+    [123, 456]
+  end
+end
+
+RSpec.describe Blog do
+  it "delegates comment_ids to DiscussionDomain" do
+    blog = Blog.new("1")
+    # I want this to raise, via sorbet-runtime
+    # Parameter 'blog_id': Expected type Integer, got type String with value "1"
+    expect(DiscussionDomain).to receive(:comment_ids_for_blog).with("1").and_return([2])
+    blog.comment_ids
+  end
+
+  it "delegates comment_ids to DiscussionDomain 2" do
+    blog = Blog.new(1)
+    # I want this to raise, via sorbet-runtime
+    # Return value: Expected type Array[Integer], got type Array[String] with value ["2"]
+    expect(DiscussionDomain).to receive(:comment_ids_for_blog).with(1).and_return(["2"])
+    blog.comment_ids
+  end
+end
+
+RSpec::Core::Runner.autorun

--- a/sorbet-demonstration.rb
+++ b/sorbet-demonstration.rb
@@ -29,20 +29,26 @@ class DiscussionDomain
 end
 
 RSpec.describe Blog do
-  it "delegates comment_ids to DiscussionDomain" do
+  it "#comment_ids raises Sorbet error when mock has bad parameter type" do
     blog = Blog.new("1")
-    # I want this to raise, via sorbet-runtime
-    # Parameter 'blog_id': Expected type Integer, got type String with value "1"
+
     expect(DiscussionDomain).to receive(:comment_ids_for_blog).with("1").and_return([2])
-    blog.comment_ids
+
+    expect { blog.comment_ids }.to raise_error(
+      TypeError,
+      /Parameter 'blog_id': Expected type Integer, got type String with value "1"/
+    )
   end
 
-  it "delegates comment_ids to DiscussionDomain 2" do
+  it "#comment_ids raises Sorbet error when mock has bad return type" do
     blog = Blog.new(1)
-    # I want this to raise, via sorbet-runtime
-    # Return value: Expected type Array[Integer], got type Array[String] with value ["2"]
+
     expect(DiscussionDomain).to receive(:comment_ids_for_blog).with(1).and_return(["2"])
-    blog.comment_ids
+
+    expect { blog.comment_ids }.to raise_error(
+      TypeError,
+      /Parameter 'blog_id': Expected type Array[Integer], got type Array[String] with value ["2"]/
+    )
   end
 end
 

--- a/sorbet-demonstration.rb
+++ b/sorbet-demonstration.rb
@@ -47,7 +47,7 @@ RSpec.describe Blog do
 
     expect { blog.comment_ids }.to raise_error(
       TypeError,
-      /Parameter 'blog_id': Expected type Array[Integer], got type Array[String] with value ["2"]/
+      /Parameter 'blog_id': Expected type Array\[Integer\], got type Array\[String\] with value \["2"\]/
     )
   end
 end

--- a/sorbet-demonstration.rb
+++ b/sorbet-demonstration.rb
@@ -32,7 +32,7 @@ RSpec.describe Blog do
   it "#comment_ids raises Sorbet error when mock has bad parameter type" do
     blog = Blog.new("1")
 
-    expect(DiscussionDomain).to receive(:comment_ids_for_blog).with("1").and_return([2])
+    expect(DiscussionDomain).to receive(:comment_ids_for_blog).once.with("1").and_return([2])
 
     expect { blog.comment_ids }.to raise_error(
       TypeError,
@@ -43,7 +43,7 @@ RSpec.describe Blog do
   it "#comment_ids raises Sorbet error when mock has bad return type" do
     blog = Blog.new(1)
 
-    expect(DiscussionDomain).to receive(:comment_ids_for_blog).with(1).and_return(["2"])
+    expect(DiscussionDomain).to receive(:comment_ids_for_blog).once.with(1).and_return(["2"])
 
     expect { blog.comment_ids }.to raise_error(
       TypeError,


### PR DESCRIPTION
This is intended as a demonstration of the concept proposed in https://github.com/sorbet/sorbet/issues/5683.

At present the implementation is order dependent, I believe because the sorbet addition is interfering with RSpec's identification of the mocked method, resulting in it not removing the mock of the first test when the second is run?

You can see this by running `ruby ./sorbet-demonstration.rb`